### PR TITLE
Update main.dart

### DIFF
--- a/web/main.dart
+++ b/web/main.dart
@@ -16,7 +16,7 @@ import 'package:http/browser_client.dart';
 
 void main() {
   bootstrap(AppComponent, [
-    provide(BrowserClient, useFactory: () => new BrowserClient(), deps: [])
+    provide(Client, useFactory: () => new BrowserClient(), deps: [])
   ]);
 }
 */


### PR DESCRIPTION
Minor detail in commented code. Also the web tutorial had a similar issue, should provide Client instead of BrowserClient when using real API